### PR TITLE
No JIRA: Bumps integration pod mem limit to 1GB

### DIFF
--- a/vars/chefPipeline.groovy
+++ b/vars/chefPipeline.groovy
@@ -65,7 +65,7 @@ def call(Closure body = null) {
                   ttyEnabled true
                   command 'cat'
                   resourceRequestCpu '500m'
-                  resourceLimitMemory '500Mi'
+                  resourceLimitMemory '1Gi'
                 }
               }
             }


### PR DESCRIPTION
Bumps the memory limit for integration tests runners from 500MB to 1GB.