### PR TITLE
No-Jira: allow the addition of a target stage in image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ The `Image#build` method takes a `Map` of build arguments.
 
 | Argument   | Type   | Required | Description                                          |
 |------------|--------|:--------:|------------------------------------------------------|
-| gitUrl     | String |     Y    | URL to remote Git repository.  Set to `env.GIT_URL`. | 
+| gitUrl     | String |     Y    | URL to remote Git repository.  Set to `env.GIT_URL`. |
 | buildArgs  | Map    |     N    | `foo=bar` pairings for `docker build --build-arg`.   |
 | dockerFile | String |     N    | Name of `Dockerfile` file, defaults to `Dockerfile`. |
+| target     | String |     N    | Target stage to build to in the docker build.        |
 
 ### Environment
 


### PR DESCRIPTION
This allows the user of the `Image` class in a jenkins pipeline to indicate a specific phase of the build they would like to target.

Example usages as follows:

1. Default build to the end of the file
```
image = new Image(this, "invocaops/web_app", ["master", "latest"])
image.build()
```
=> `docker build --pull -t invocaops/web_app:master -f Dockerfile .`


2. Build to a specific target
```
image = new Image(this, "invocaops/web_app", ["master", "latest"])
image.build(target: "development")
```
=> `docker build --pull -t invocaops/web_app:master -f Dockerfile --target development .`