### PR TITLE
TECH-4468: add new deprecation check command

### DIFF
--- a/src/com/invoca/ci/DeprecationCheck.groovy
+++ b/src/com/invoca/ci/DeprecationCheck.groovy
@@ -4,14 +4,21 @@ package com.invoca.ci
 
 import com.invoca.github.GitHubStatus
 
-def deprecationCheck(String testOutput, Map<String, Object> githubStatusConfig) {
+def runWithDeprecationWarningCheck(String script, Map<String, Object> githubStatusConfig) {
+  def testOutput = sh(returnStdout: true, script: "${script} 2>&1")
+  echo testOutput
+
+  githubStatusConfig.context = 'deprecation-warning-check'
+  githubStatusConfig.script  = this
+
   if (testOutput.contains("Unexpected Deprecation Warnings Encountered")) {
-    githubStatusConfig.status = 'failure'
+    githubStatusConfig.status      = 'failure'
+    githubStatusConfig.description = 'Unexpected deprecation warnings encountered'
   } else {
-    githubStatusConfig.status = 'success'
+    githubStatusConfig.status      = 'success'
+    githubStatusConfig.description = 'No unexpected deprecation warnings encountered'
   }
 
-  githubStatusConfig.script = this
   GitHubStatus.update(githubStatusConfig)
 
   return githubStatusConfig.status == 'success'

--- a/src/com/invoca/ci/DeprecationCheck.groovy
+++ b/src/com/invoca/ci/DeprecationCheck.groovy
@@ -1,0 +1,18 @@
+#!/usr/bin/groovy
+
+package com.invoca.ci
+
+import com.invoca.github.GitHubStatus
+
+def deprecationCheck(String testOutput, Map<String, Object> githubStatusConfig) {
+  if (testOutput.contains("Unexpected Deprecation Warnings Encountered")) {
+    githubStatusConfig.status = 'failure'
+  } else {
+    githubStatusConfig.status = 'success'
+  }
+
+  githubStatusConfig.script = this
+  GitHubStatus.update(githubStatusConfig)
+
+  return githubStatusConfig.status == 'success'
+}


### PR DESCRIPTION
Adds a new `deprecationCheck` method that can be pulled into any build to check the test output for deprecation warnings and report a status based on their existence.