### PR TITLE
TECH-4570: Write test output to file and archive it

### DIFF
--- a/src/com/invoca/ci/DeprecationWarnings.groovy
+++ b/src/com/invoca/ci/DeprecationWarnings.groovy
@@ -54,13 +54,13 @@ class DeprecationWarnings {
 
     this.testOutput.split("\n").each {
       if (it == UNEXPECTED_DEPRECATIONS_START) {
-        warnings << "=====\n" + UNEXPECTED_DEPRECATIONS_START
+        warnings.push("=====\n" + UNEXPECTED_DEPRECATIONS_START)
         withinUnexpectedDeprecationOutput = true
       } else if (withinUnexpectedDeprecationOutput && it == UNEXPECTED_DEPRECATIONS_END) {
-        warnings << it
+        warnings.push(it)
         withinUnexpectedDeprecationOutput = false
       } else if (withinUnexpectedDeprecationOutput || it.contains(DEPRECATION_WARNING_PREFIX)) {
-        warnings << it
+        warnings.push(it)
       }
     }
 

--- a/src/com/invoca/ci/DeprecationWarnings.groovy
+++ b/src/com/invoca/ci/DeprecationWarnings.groovy
@@ -49,18 +49,18 @@ class DeprecationWarnings {
   }
 
   private String extractWarnings() {
-    String[] warnings = []
+    List<String> warnings = new ArrayList<String>();
     boolean withinUnexpectedDeprecationOutput = false
 
     this.testOutput.split("\n").each {
       if (it == UNEXPECTED_DEPRECATIONS_START) {
-        warnings.push("=====\n" + UNEXPECTED_DEPRECATIONS_START)
+        warnings.add("=====\n" + UNEXPECTED_DEPRECATIONS_START)
         withinUnexpectedDeprecationOutput = true
       } else if (withinUnexpectedDeprecationOutput && it == UNEXPECTED_DEPRECATIONS_END) {
-        warnings.push(it)
+        warnings.add(it)
         withinUnexpectedDeprecationOutput = false
       } else if (withinUnexpectedDeprecationOutput || it.contains(DEPRECATION_WARNING_PREFIX)) {
-        warnings.push(it)
+        warnings.add(it)
       }
     }
 

--- a/src/com/invoca/ci/DeprecationWarnings.groovy
+++ b/src/com/invoca/ci/DeprecationWarnings.groovy
@@ -33,7 +33,7 @@ class DeprecationWarnings {
     githubStatusConfig.context = GITHUB_STATUS_CONTEXT
 
     if (this.warningsExist()) {
-      githubStatusConfig.targetUrl   = this.archiveWarnings()
+      githubStatusConfig.targetURL   = this.archiveWarnings()
       githubStatusConfig.status      = 'failure'
       githubStatusConfig.description = GITHUB_STATUS_FAILURE_MESSAGE
     } else {

--- a/src/com/invoca/ci/DeprecationWarnings.groovy
+++ b/src/com/invoca/ci/DeprecationWarnings.groovy
@@ -37,6 +37,7 @@ class DeprecationWarnings {
       githubStatusConfig.status      = 'failure'
       githubStatusConfig.description = GITHUB_STATUS_FAILURE_MESSAGE
     } else {
+      githubStatusConfig.targetURL   = this.script.env.RUN_DISPLAY_URL
       githubStatusConfig.status      = 'success'
       githubStatusConfig.description = GITHUB_STATUS_SUCCESS_MESSAGE
     }

--- a/vars/runWithDeprecationWarningCheck.groovy
+++ b/vars/runWithDeprecationWarningCheck.groovy
@@ -1,9 +1,12 @@
 import com.invoca.ci.DeprecationWarnings
 
 def call(String script, Map<String, Object> githubStatusConfig) {
-    def testOutput = sh(returnStdout: true, script: "${script} 2>&1")
-    echo testOutput
+  def testOutput = sh(returnStdout: true, script: "${script} 2>&1")
+  echo testOutput
 
-    githubStatusConfig.script = this
-    DeprecationWarnings.checkAndUpdateGithub(testOutput, githubStatusConfig)
-  }
+  writeFile file: 'deprecation_warnings.txt', text: testOutput
+  archiveArtifacts 'deprecation_warnings.txt'
+
+  githubStatusConfig.script = this
+  DeprecationWarnings.checkAndUpdateGithub(testOutput, githubStatusConfig)
+}

--- a/vars/runWithDeprecationWarningCheck.groovy
+++ b/vars/runWithDeprecationWarningCheck.groovy
@@ -4,10 +4,6 @@ def call(String script, Map<String, Object> githubStatusConfig) {
   def testOutput = sh(returnStdout: true, script: "${script} 2>&1")
   echo testOutput
 
-  writeFile file: 'deprecation_warnings.txt', text: testOutput
-  archiveArtifacts 'deprecation_warnings.txt'
-
   githubStatusConfig.script = this
-  githubStatusConfig.targetURL = env.BUILD_URL + "/artifact/deprecation_warnings.txt"
-  DeprecationWarnings.checkAndUpdateGithub(testOutput, githubStatusConfig)
+  DeprecationWarnings.checkAndUpdateGithub(this, testOutput, githubStatusConfig)
 }

--- a/vars/runWithDeprecationWarningCheck.groovy
+++ b/vars/runWithDeprecationWarningCheck.groovy
@@ -8,5 +8,6 @@ def call(String script, Map<String, Object> githubStatusConfig) {
   archiveArtifacts 'deprecation_warnings.txt'
 
   githubStatusConfig.script = this
+  githubStatusConfig.targetURL = env.BUILD_URL + "/artifact/deprecation_warnings.txt"
   DeprecationWarnings.checkAndUpdateGithub(testOutput, githubStatusConfig)
 }


### PR DESCRIPTION
[Jira Ticket](https://ringrevenue.atlassian.net/browse/TICKET-4570)

## Description
<!-- What is the goal of this Pull Request? -->
Improve the observability of deprecation warnings by archiving an artifact with information about them.

## Summary of Changes
<!-- What components/classes were added/removed? Was there any refactoring? -->
Update `vars/runWithDeprecationWarningCheck.groovy` to:
- Write test results to a `deprecation_warnings.txt` file.
- Archive that file.

## Gotchas
<!-- Are there any subtleties in this Pull Request that the reviewer should know about? What extra context should the reviewer have while reviewing? -->
1. Feels a little weird not to include some sort of file path to write the file to, but wasn't sure where to put it so left it at the working directory. Happy to update that if there's somewhere better for it to go.
2. I think it would be ideal for the github status link to send you to the artifacts page, but dynamically building the URL and hacking it into the `githubStatusConfig.targetUrl` didn't feel right. Any ideas?