### PR TITLE
TECH-5042: add resiliency to cacheStore and cacheRestore

### DIFF
--- a/vars/cacheRestore.groovy
+++ b/vars/cacheRestore.groovy
@@ -32,6 +32,7 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, Boolean global = false) 
         break;
       } catch(Exception ex) {
         echo "Error occurred while unpacking cache from ${cacheKey}"
+        echo "${ex.toString()}\n${ex.getStackTrace().join("\n")}"
         cacheExists = false
         sh "rm -rf ${cacheTarball}"
       }

--- a/vars/cacheRestore.groovy
+++ b/vars/cacheRestore.groovy
@@ -18,20 +18,27 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, Boolean global = false) 
 
     cacheExists = sh(script: "aws s3 ls ${cacheLocation}", returnStatus: true) == 0
     if (cacheExists) {
-      sh "aws s3 cp ${cacheLocation} ${cacheTarball} --content-type application/x-gzip"
-      break;
+      try {
+        echo "Found cache at key ${cacheKey}"
+        sh "aws s3 cp ${cacheLocation} ${cacheTarball} --content-type application/x-gzip"
+
+        echo "Unpacking cache tarball from ${cacheKey}"
+        sh "tar -xzf ${cacheTarball}"
+
+        echo "Cleaning up local cache tarball from ${cacheKey}"
+        sh "rm -rf ${cacheTarball}"
+
+        echo 'Cache restored!'
+        break;
+      } catch(Exception ex) {
+        echo "Error occurred while unpacking cache from ${cacheKey}"
+        cacheExists = false
+        sh "rm -rf ${cacheTarball}"
+      }
     }
   }
 
-  if (cacheExists) {
-    echo 'Unpacking cache tarball'
-    sh "tar -xzf ${cacheTarball}"
-
-    echo 'Cleaning up local cache tarball'
-    sh "rm -rf ${cacheTarball}"
-
-    echo 'Cache restored'
-  } else {
+  if (!cacheExists) {
     echo 'Unable to find cache stored for any of the provided keys'
   }
 }

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -21,6 +21,7 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsT
       sh "aws s3 cp ${cacheTarball} ${cacheLocation} --content-type application/x-gzip"
     } catch(Exception ex) {
       echo "Error occurred while pushing cache to ${cacheKey}"
+      echo "${ex.toString()}\n${ex.getStackTrace().join("\n")}"
     }
   }
 

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -16,8 +16,12 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsT
 
   echo 'Pushing cache to AWS'
   cacheKeys.each { cacheKey ->
-    String cacheLocation = "${cacheDirectory}/${cacheKey}.tar.gz"
-    sh "aws s3 cp ${cacheTarball} ${cacheLocation} --content-type application/x-gzip"
+    try {
+      String cacheLocation = "${cacheDirectory}/${cacheKey}.tar.gz"
+      sh "aws s3 cp ${cacheTarball} ${cacheLocation} --content-type application/x-gzip"
+    } catch(Exception ex) {
+      echo "Error occurred while pushing cache to ${cacheKey}"
+    }
   }
 
   echo 'Cleaning up local cache tarball'


### PR DESCRIPTION
This PR is adding resiliency to the `cacheStore` and `cacheRestore` methods by eating the errors that can happen at any of the layers of operation.  

**cacheRestore**
* This now has error handling during the pulling and unpacking of the cache tarballs so that it will try the next key in case there is a corrupted cache
* Additional logging was added

**cacheStore**
* This now has error handling during the pushing of cache tarballs to make sure that it continues on to push additional keys
* Additional logging was added