### PR TITLE
No-Jira: serialize cachekeys used to remove non-word characters

### DIFF
--- a/src/com/invoca/util/CacheUtil.groovy
+++ b/src/com/invoca/util/CacheUtil.groovy
@@ -3,6 +3,6 @@ package com.invoca.util
 
 class CacheUtil {
   static String sanitizeCacheKey(String cacheKey) {
-    return cacheKey.replaceAll("\\W", "");
+    return cacheKey.replaceAll("\\W", "-");
   }
 }

--- a/src/com/invoca/util/CacheUtil.groovy
+++ b/src/com/invoca/util/CacheUtil.groovy
@@ -1,0 +1,8 @@
+#!/usr/bin/groovy
+package com.invoca.util
+
+class CacheUtil {
+  static String sanitizeCacheKey(String cacheKey) {
+    return cacheKey.replaceAll("\\W", "");
+  }
+}

--- a/vars/cacheRestore.groovy
+++ b/vars/cacheRestore.groovy
@@ -13,25 +13,28 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, Boolean global = false) 
   Boolean cacheExists = false
   String cacheTarball = ""
   for (String cacheKey : cacheKeys) {
-    cacheTarball = "${cacheKey}.tar.gz"
+    String serializedCacheKey = cacheKey.replaceAll("\\W", "")
+    echo "Serialized cacheKey from ${cacheKey} => ${serializedCacheKey}"
+
+    cacheTarball = "${serializedCacheKey}.tar.gz"
     String cacheLocation = "${cacheDirectory}/${cacheTarball}"
 
     cacheExists = sh(script: "aws s3 ls ${cacheLocation}", returnStatus: true) == 0
     if (cacheExists) {
       try {
-        echo "Found cache at key ${cacheKey}"
+        echo "Found cache at key ${serializedCacheKey}"
         sh "aws s3 cp ${cacheLocation} ${cacheTarball} --content-type application/x-gzip"
 
-        echo "Unpacking cache tarball from ${cacheKey}"
+        echo "Unpacking cache tarball from ${serializedCacheKey}"
         sh "tar -xzf ${cacheTarball}"
 
-        echo "Cleaning up local cache tarball from ${cacheKey}"
+        echo "Cleaning up local cache tarball from ${serializedCacheKey}"
         sh "rm -rf ${cacheTarball}"
 
         echo 'Cache restored!'
         break;
       } catch(Exception ex) {
-        echo "Error occurred while unpacking cache from ${cacheKey}"
+        echo "Error occurred while unpacking cache from ${serializedCacheKey}"
         echo "${ex.toString()}\n${ex.getStackTrace().join("\n")}"
         cacheExists = false
         sh "rm -rf ${cacheTarball}"

--- a/vars/cacheRestore.groovy
+++ b/vars/cacheRestore.groovy
@@ -4,6 +4,8 @@
  * @param
 */
 
+import com.invoca.util.CacheUtil
+
 void call(String s3Bucket, ArrayList<String> cacheKeys, Boolean global = false) {
   String cacheDirectory = global ? "s3://${s3Bucket}/jenkins_cache" : "s3://${s3Bucket}/jenkins_cache/${env.JOB_NAME.replaceAll("\\W", "")}";
   // Verify that aws-cli is installed before proceeding
@@ -13,7 +15,7 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, Boolean global = false) 
   Boolean cacheExists = false
   String cacheTarball = ""
   for (String cacheKey : cacheKeys) {
-    String serializedCacheKey = cacheKey.replaceAll("\\W", "")
+    String serializedCacheKey = CacheUtil.sanitizeCacheKey(cacheKey)
     echo "Serialized cacheKey from ${cacheKey} => ${serializedCacheKey}"
 
     cacheTarball = "${serializedCacheKey}.tar.gz"

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -4,6 +4,8 @@
  * @param
 */
 
+import com.invoca.util.CacheUtil
+
 void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsToCache, Boolean global = false) {
   String cacheDirectory       = global ? "s3://${s3Bucket}/jenkins_cache" : "s3://${s3Bucket}/jenkins_cache/${env.JOB_NAME.replaceAll("\\W", "")}";
   String serializedTarballKey = CacheUtil.sanitizeCacheKey(cacheKeys[0])

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -16,11 +16,13 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsT
 
   echo 'Pushing cache to AWS'
   cacheKeys.each { cacheKey ->
+    String serializedCacheKey = cacheKey.replaceAll("\\W", "")
+    echo "Serialized cacheKey from ${cacheKey} => ${serializedCacheKey}"
     try {
-      String cacheLocation = "${cacheDirectory}/${cacheKey}.tar.gz"
+      String cacheLocation = "${cacheDirectory}/${serializedCacheKey}.tar.gz"
       sh "aws s3 cp ${cacheTarball} ${cacheLocation} --content-type application/x-gzip"
     } catch(Exception ex) {
-      echo "Error occurred while pushing cache to ${cacheKey}"
+      echo "Error occurred while pushing cache to ${serializedCacheKey}"
       echo "${ex.toString()}\n${ex.getStackTrace().join("\n")}"
     }
   }

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -5,8 +5,9 @@
 */
 
 void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsToCache, Boolean global = false) {
-  String cacheDirectory = global ? "s3://${s3Bucket}/jenkins_cache" : "s3://${s3Bucket}/jenkins_cache/${env.JOB_NAME.replaceAll("\\W", "")}";
-  String cacheTarball   = "${cacheKeys[0]}.tar.gz"
+  String cacheDirectory       = global ? "s3://${s3Bucket}/jenkins_cache" : "s3://${s3Bucket}/jenkins_cache/${env.JOB_NAME.replaceAll("\\W", "")}";
+  String serializedTarballKey = CacheUtil.sanitizeCacheKey(cacheKeys[0])
+  String cacheTarball         = "${serializedTarballKey}.tar.gz"
 
   // Verify that aws-cli is installed before proceeding
   sh 'which aws'

--- a/vars/cacheStore.groovy
+++ b/vars/cacheStore.groovy
@@ -16,7 +16,7 @@ void call(String s3Bucket, ArrayList<String> cacheKeys, ArrayList<String> itemsT
 
   echo 'Pushing cache to AWS'
   cacheKeys.each { cacheKey ->
-    String serializedCacheKey = cacheKey.replaceAll("\\W", "")
+    String serializedCacheKey = CacheUtil.sanitizeCacheKey(cacheKey)
     echo "Serialized cacheKey from ${cacheKey} => ${serializedCacheKey}"
     try {
       String cacheLocation = "${cacheDirectory}/${serializedCacheKey}.tar.gz"


### PR DESCRIPTION
NoJira PR to fix a bug in the `cacheStore` and `cacheRestore` functions that were causing builds to crash when having a `/` in a cache key.